### PR TITLE
Assign proper listener priority

### DIFF
--- a/src/main/java/xyz/nkomarn/harbor/listener/BedListener.java
+++ b/src/main/java/xyz/nkomarn/harbor/listener/BedListener.java
@@ -3,6 +3,7 @@ package xyz.nkomarn.harbor.listener;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerBedEnterEvent;
 import org.bukkit.event.player.PlayerBedLeaveEvent;
@@ -25,7 +26,7 @@ public class BedListener implements Listener {
         this.playerManager = harbor.getPlayerManager();
     }
 
-    @EventHandler(ignoreCancelled = true)
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.MONITOR)
     public void onBedEnter(PlayerBedEnterEvent event) {
         if (event.getBedEnterResult() != PlayerBedEnterEvent.BedEnterResult.OK) {
             return;


### PR DESCRIPTION
The bed listener is currently listening on a medium (default) priority, but is only used for monitoring.
Therefore it should use the monitoring level to ensure that the event was already handled by all other listeners which can potentially modify this event.
The current behaviour can cause issues with plugins which use high or highest priority on the bed enter event to cancel the event. They do this because they want to make the final decision if the player is allowed to enter the bed.
Currently harbor would already mark these players as sleeping, altohugh they are not because the event was canceled afterwards.