### PR TITLE
Feature: Better AFK

### DIFF
--- a/src/main/java/xyz/nkomarn/harbor/listener/AfkListeners.java
+++ b/src/main/java/xyz/nkomarn/harbor/listener/AfkListeners.java
@@ -1,0 +1,104 @@
+package xyz.nkomarn.harbor.listener;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.player.AsyncPlayerChatEvent;
+import org.bukkit.event.player.PlayerCommandPreprocessEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.scheduler.BukkitRunnable;
+import xyz.nkomarn.harbor.util.PlayerManager;
+
+import java.util.ArrayDeque;
+import java.util.Queue;
+
+public final class AfkListeners extends BukkitRunnable implements Listener {
+
+    private final PlayerManager playerManager;
+    private double checksToMake = 0;
+    private final Queue<AfkPlayer> players = new ArrayDeque<>();
+
+    public AfkListeners(PlayerManager playerManager) {
+        this.playerManager = playerManager;
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    public void onChat(AsyncPlayerChatEvent event) {
+        playerManager.updateActivity(event.getPlayer());
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    public void onCommand(PlayerCommandPreprocessEvent event) {
+        playerManager.updateActivity(event.getPlayer());
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    public void onInventoryClick(InventoryClickEvent event) {
+        playerManager.updateActivity((Player) event.getWhoClicked());
+    }
+
+    @EventHandler
+    public void onJoin(PlayerJoinEvent event) {
+        players.add(new AfkPlayer(event.getPlayer()));
+    }
+
+    @EventHandler
+    public void onLeave(PlayerQuitEvent event) {
+        players.remove(new AfkPlayer(event.getPlayer()));
+    }
+
+    @Override
+    public void run() {
+        if (players.isEmpty()) return;
+
+        // We want every player to get a check every 20 ticks.
+        checksToMake += players.size() / 20.0;
+        long start = System.currentTimeMillis();
+
+        // We assume that a tick should take 50 ms at max.
+        // To leave some space for other plugins we only take 20 ms of a tick.
+        while (System.currentTimeMillis() - start < 20 && checksToMake > 0) {
+            AfkPlayer afkPlayer = players.poll();
+            if (afkPlayer.changed()) {
+                playerManager.updateActivity(afkPlayer.player);
+            }
+            players.add(afkPlayer);
+            checksToMake--;
+        }
+    }
+
+    private static class AfkPlayer {
+        private final Player player;
+        private int hash;
+
+        public AfkPlayer(Player player) {
+            this.player = player;
+        }
+
+        /**
+         * Check if the player changed its position since the last check
+         * @return true if the position changed
+         */
+        private boolean changed() {
+            int hash = player.getLocation().hashCode();
+            boolean changed = hash != this.hash;
+            this.hash = hash;
+            return changed;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            AfkPlayer afkPlayer = (AfkPlayer) o;
+            return player.getUniqueId().equals(afkPlayer.player.getUniqueId());
+        }
+
+        @Override
+        public int hashCode() {
+            return player.getUniqueId().hashCode();
+        }
+    }
+}

--- a/src/main/java/xyz/nkomarn/harbor/listener/BedListener.java
+++ b/src/main/java/xyz/nkomarn/harbor/listener/BedListener.java
@@ -11,7 +11,8 @@ import xyz.nkomarn.harbor.Harbor;
 import xyz.nkomarn.harbor.util.Messages;
 import xyz.nkomarn.harbor.util.PlayerManager;
 
-import java.util.concurrent.TimeUnit;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 
 public class BedListener implements Listener {
 
@@ -37,7 +38,7 @@ public class BedListener implements Listener {
         }
 
         Bukkit.getScheduler().runTaskLater(harbor, () -> {
-            playerManager.setCooldown(player, System.currentTimeMillis());
+            playerManager.setCooldown(player, Instant.now());
             harbor.getMessages().sendWorldChatMessage(event.getBed().getWorld(), messages.prepareMessage(
                     player, harbor.getConfiguration().getString("messages.chat.player-sleeping"))
             );
@@ -51,7 +52,7 @@ public class BedListener implements Listener {
         }
 
         Bukkit.getScheduler().runTaskLater(harbor, () -> {
-            playerManager.setCooldown(event.getPlayer(), System.currentTimeMillis());
+            playerManager.setCooldown(event.getPlayer(), Instant.now());
             harbor.getMessages().sendWorldChatMessage(event.getBed().getWorld(), messages.prepareMessage(
                     event.getPlayer(), harbor.getConfiguration().getString("messages.chat.player-left-bed"))
             );
@@ -74,6 +75,6 @@ public class BedListener implements Listener {
         }
 
         int cooldown = harbor.getConfiguration().getInteger("messages.chat.message-cooldown");
-        return TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis() - playerManager.getCooldown(player)) < cooldown;
+        return playerManager.getCooldown(player).until(Instant.now(), ChronoUnit.MINUTES) < cooldown;
     }
 }

--- a/src/main/java/xyz/nkomarn/harbor/util/PlayerManager.java
+++ b/src/main/java/xyz/nkomarn/harbor/util/PlayerManager.java
@@ -108,27 +108,4 @@ public class PlayerManager implements Listener {
         cooldowns.remove(uuid);
         playerActivity.remove(uuid);
     }
-
-    private final class AfkListeners implements Listener {
-
-        @EventHandler(ignoreCancelled = true)
-        public void onChat(AsyncPlayerChatEvent event) {
-            updateActivity(event.getPlayer());
-        }
-
-        @EventHandler(ignoreCancelled = true)
-        public void onCommand(PlayerCommandPreprocessEvent event) {
-            updateActivity(event.getPlayer());
-        }
-
-        @EventHandler(ignoreCancelled = true)
-        public void onMove(PlayerMoveEvent event) {
-            updateActivity(event.getPlayer());
-        }
-
-        @EventHandler(ignoreCancelled = true)
-        public void onInventoryClick(InventoryClickEvent event) {
-            updateActivity((Player) event.getWhoClicked());
-        }
-    }
 }


### PR DESCRIPTION
I saw #84 and decided to provide a proposal for the implementation.

The current implementation will spread the afk check into 20 ticks. At the end of 20 ticks every player will be checked one time.
The implementation also provides lagg and will jump to the next tick if for some reasons the current calculation takes too long. However this shouldnt happen.

The current implementation compares the hased location of the last check and the current location and decides on the base of the hash if the player has moved in any way or not.

I also changed the cooldown and playerActivity to Instants. These provide a more solid and more readable solution to measure durations between time points.